### PR TITLE
Fixed the React Router and removed redundant imports in the Views

### DIFF
--- a/src/presenter/ReactRoot.jsx
+++ b/src/presenter/ReactRoot.jsx
@@ -1,39 +1,36 @@
-// import Browsing from "./browsingPresenter.jsx"
-// import ResultDetails from "./resultDetailsPresenter.jsx"
-// import ResultsSummary from "./resultsSummaryPresenter.jsx";
-// import Welcome from "./welcomePresenter.jsx";
-//import {observer} from "mobx-react-lite"
+import Browsing from "./browsingPresenter.jsx"
+import ResultDetails from "./resultDetailsPresenter.jsx"
+import ResultsSummary from "./resultsSummaryPresenter.jsx";
+import Welcome from "./welcomePresenter.jsx";
+import {observer} from "mobx-react-lite"
 
 import { createHashRouter, RouterProvider } from "react-router-dom";
 
 
-export default function ReactRoot(){
+export default observer (function ReactRoot(){
 
     function makeRouter(){
         return createHashRouter([
         {
             path: "/",
-            element: <div><p>WELCOME</p></div>,
-        },
-        {
-            path: "/1",
-            element: <div><p>WELCOME1</p></div>,
+            element: <Welcome/>,
         },
         {
             path: "/browsing",
-            element: <div><p>BROWSING</p></div>,
+            element: <Browsing/>,
         },
         {
             path: "/result-details",
-            element: <div><p>RESULTS DETAILS</p></div>,
+            element: <ResultDetails/>,
         },
         {
             path: "/results-summary",
-            element: <div><p>RESULTS SUMMARY</p></div>,
+            element: <ResultsSummary/>,
         },
         
     ])
     }
     return ( <div><RouterProvider router={makeRouter()} /></div> );
 }
+)
 

--- a/src/view/browsingView.jsx
+++ b/src/view/browsingView.jsx
@@ -1,5 +1,3 @@
-import "/src/App.css"
-
 /* Functional JSX component. Name must start with capital letter */
 function BrowsingView(props){
     return(

--- a/src/view/resultDetailsView.jsx
+++ b/src/view/resultDetailsView.jsx
@@ -1,5 +1,3 @@
-import "/src/App.css"
-
 /* Functional JSX component. Name must start with capital letter */
 function ResultDetailsView(props){
     return(

--- a/src/view/resultsSummaryView.jsx
+++ b/src/view/resultsSummaryView.jsx
@@ -1,5 +1,3 @@
-import "/src/App.css"
-
 /* Functional JSX component. Name must start with capital letter */
 function ResultsSummaryView(props){
     return(

--- a/src/view/welcomeView.jsx
+++ b/src/view/welcomeView.jsx
@@ -1,5 +1,3 @@
-import "/src/App.css"
-
 /* Functional JSX component. Name must start with capital letter */
 function WelcomeView(props){
     return(


### PR DESCRIPTION
I removed redundant imports to App.css file in the View files and fixed the React Router. I think the main issue with the router actually stemmed from people using the wrong path to test stuff.

The path to navigate to the browsing was supposed to be http://localhost:5173/#/browsing instead of http://localhost:5173/browsing